### PR TITLE
Add validation for promo operation and field

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -545,6 +545,9 @@ function promo($widget)
     // 获取操作
     $operate = $widget->request->get('operate');
     $field = $widget->request->get('field');
+    if (!in_array($operate, $allowOperates, true) || !in_array($field, $allowFields, true)) {
+        $widget->response->throwJson(['status'=>0,'msg'=>'非法请求']);
+    }
     $value = $widget->request->filter('int')->get('value');
     $value = $value === null ? 100 : $value; // 100 起步
 


### PR DESCRIPTION
## Summary
- validate promo widget requests to allow only permitted operations and fields

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689dd22b1e34833183a54338bcb116de