### PR TITLE
Sanitize SEO URL output

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -355,7 +355,7 @@ function seoUrl($that)
     //     $url = $that->permalink();
     // }
     // return $url;
-    echo $that->request->getRequestUrl();
+    echo htmlspecialchars($that->request->getRequestUrl(), ENT_QUOTES);
 }
 
 /**


### PR DESCRIPTION
## Summary
- escape request URL in `seoUrl` to ensure safe meta tag URLs

## Testing
- `php -l functions.php`
- `php -l php_modules/default_head.php`


------
https://chatgpt.com/codex/tasks/task_e_689dd22f4c8c83319c550187e99aed5d