### PR TITLE
Sanitize comment mention author names

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1132,7 +1132,7 @@ function get_comment_at($coid)
         $author = $arow['author'] ?? '';
 
         if ($author) {
-            $href = '<a class="comment-list-item-relation" href="#comment-' . $parent . '">@' . $author . '</a>';
+            $href = '<a class="comment-list-item-relation" href="#comment-' . $parent . '">@' . htmlspecialchars($author, ENT_QUOTES) . '</a>';
             echo $href;
         } else {
             echo '';


### PR DESCRIPTION
## Summary
- sanitize referenced comment author names with `htmlspecialchars`

## Testing
- `php -l functions.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd23185dc8331922eeceb006f1021