### PR TITLE
Promote site title in header and style New banner

### DIFF
--- a/php_modules/header.php
+++ b/php_modules/header.php
@@ -2,18 +2,17 @@
   <div class="header-container">
     <div class="header-content">
       <div class="header-left">
-        <a class="header-logo" href="<?php $this->options->siteUrl();?>" target="_self"><?php $this->options->title();?></a>
         <nav class="header-nav">
           <div class="header-nav-mobile-menu-wrap">
-            <div class="header-nav-mobile-menu">
-              HOME
-              <i class="jj-icon jj-icon-down header-nav-mobile-menu-icon"></i>
+              <div class="header-nav-mobile-menu" style="font-size:24px;font-weight:bold;">
+                <?php $this->options->title();?>
+                <i class="jj-icon jj-icon-down header-nav-mobile-menu-icon"></i>
             </div>
           </div>
           <ul class="header-nav-list">
             <li>
               <a class="header-nav-list-item <?php if ($this->is('index')) {echo 'active';}
-;?>"  target="_self" href="<?php $this->options->siteUrl();?>" title="HOME">HOME</a>
+  ;?>"  target="_self" href="<?php $this->options->siteUrl();?>" title="<?php $this->options->title();?>" style="font-size:24px;font-weight:bold;"><?php $this->options->title();?></a>
             </li>
             <?php $this->widget('Widget_Contents_Page_List')->to($pages);?>
             <?php while ($pages->next()): ?>

--- a/php_modules/home/nav.php
+++ b/php_modules/home/nav.php
@@ -1,6 +1,6 @@
 <nav class="article-nav">
   <div class="article-nav-content">
-    <a class="article-nav-item" href="javascript:;" target="_self" title="New!">New!</a>
+    <a class="article-nav-item" href="javascript:;" target="_self" title="New!" style="background: linear-gradient(90deg,#ff4e50,#f9d423);-webkit-background-clip:text;color:transparent;">New!</a>
     <span class="article-nav-line"></span>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- Replace home navigation text with the actual site title and enlarge its font to act as the page heading
- Remove duplicate logo link and show title in mobile menu
- Add gradient color style to the `New!` list banner

## Testing
- `php -l php_modules/header.php`
- `php -l php_modules/home/nav.php`


------
https://chatgpt.com/codex/tasks/task_e_689e0106803c833187ad5628bd1c02c5