### PR TITLE
Use sitemap path without extension

### DIFF
--- a/php_modules/footer.php
+++ b/php_modules/footer.php
@@ -11,7 +11,7 @@ $linksLink = getHidePage($this, 'links');
       <?php if (!empty($linksLink["href"])): ?>
         <a href="<?php echo $linksLink["href"]; ?>" target="_self" title="<?php echo $linksLink["title"]; ?>"><?php echo $linksLink["title"]; ?></a>
       <?php endif;?>
-      <a href="<?php $this->options->siteUrl();?>sitemap.xml" target="_blank" title="Sitemap">Sitemap</a>
+      <a href="<?php $this->options->siteUrl();?>sitemap" target="_blank" title="Sitemap">Sitemap</a>
     </div>
     <div class="footer-item">
       Copyright: <?php $this->options->title();?>


### PR DESCRIPTION
## Summary
- fix sitemap link to drop .xml extension

## Testing
- `php -l php_modules/footer.php`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689e0c271084833185aaa22f48ca3ecf